### PR TITLE
fix: watchOS features styling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
   "workbench.editor.customLabels.patterns": {
     "**/index.vue": "${dirname} (${filename})",
     "**/[[]*.vue": "${dirname}/${filename}"
+  },
+  "[astro]": {
+    "editor.defaultFormatter": "astro-build.astro-vscode"
   }
 }

--- a/arisamakes-website/src/pages/rowcounter/watchos.astro
+++ b/arisamakes-website/src/pages/rowcounter/watchos.astro
@@ -49,11 +49,12 @@ import WatchSweaterDarktealIconSetting from '../../assets/3.0sweater+darkteal+ic
         <p class="pl-10 font-bold">Update 3.0 is now available!</p>
       </div>
 
-      <h3
+      <h2
+        id="screenshots"
         class="my-8 flex justify-center text-3xl font-extrabold leading-8 tracking-tight text-gray-900 sm:text-3xl sm:leading-9"
       >
         Screenshots
-      </h3>
+      </h2>
 
       <div class="flex flex-wrap">
         <img
@@ -108,8 +109,13 @@ import WatchSweaterDarktealIconSetting from '../../assets/3.0sweater+darkteal+ic
           knit projects!
         </p>
         <section class="font-sans">
-          <p>Features include:</p>
-          <ul class="mt-4 ml-15 text-xl list-disc text-left list-outside">
+          <h2
+            id="featured"
+            class="mt-8 flex justify-center text-2xl leading-8 tracking-tight text-gray-900 sm:text-3xl sm:leading-9"
+          >
+            Features include:
+          </h2>
+          <ul class="mt-2 ml-15 text-xl list-disc text-left list-outside">
             <li class="py-2">
               <strong>Multiple Row Counters</strong>: Create up to 10 row
               counters to track multiple projects!

--- a/arisamakes-website/src/pages/rowcounter/watchos.astro
+++ b/arisamakes-website/src/pages/rowcounter/watchos.astro
@@ -110,20 +110,20 @@ import WatchSweaterDarktealIconSetting from '../../assets/3.0sweater+darkteal+ic
         <section class="font-sans">
           <p>Features include:</p>
           <ul class="mt-4 ml-15 text-xl list-disc list-inside">
-            <li>
+            <li class="py-2">
               <strong>Multiple Row Counters</strong>: Create up to 10 row
               counters to track multiple projects!
             </li>
-            <li>
+            <li class="py-2">
               <strong>Track Row Repeats</strong>: Automatically reset the
               counter on a specific row to track repeats. Helpful for when
               following a repeating pattern!
             </li>
-            <li>
+            <li class="py-2">
               <strong>Customizable Counter</strong>: Customize your row counter
               with 6 hand-drawn icons and 5 background colors.
             </li>
-            <li>
+            <li class="py-2">
               <strong>Save History</strong>: Tracks every increase or decrease
               on the counter with the date and time. You can tap the entry to
               rollback to a previous save!

--- a/arisamakes-website/src/pages/rowcounter/watchos.astro
+++ b/arisamakes-website/src/pages/rowcounter/watchos.astro
@@ -109,7 +109,7 @@ import WatchSweaterDarktealIconSetting from '../../assets/3.0sweater+darkteal+ic
         </p>
         <section class="font-sans">
           <p>Features include:</p>
-          <ul class="mt-4 ml-15 text-xl list-disc list-inside">
+          <ul class="mt-4 ml-15 text-xl list-disc text-left list-outside">
             <li class="py-2">
               <strong>Multiple Row Counters</strong>: Create up to 10 row
               counters to track multiple projects!

--- a/arisamakes-website/src/pages/rowcounter/watchos.astro
+++ b/arisamakes-website/src/pages/rowcounter/watchos.astro
@@ -1,60 +1,62 @@
 ---
 import Layout from '../../layouts/Layout.astro';
-import ArisaMakesLogo from "../../assets/icon_234.png";
-import WatchCakeDarkTeal from "../../assets/3.0cake+darkteal.png";
-import WatchRowCounterList from "../../assets/3.0rowcounterlist.png";
-import WatchCrochetHankPinkSetting from "../../assets/3.0crochethank+pinksettings.png";
-import WatchCrochetHankPinkDetail from "../../assets/3.0crochethank+pinkdetail.png";
-import WatchSweaterDarktealIconSetting from "../../assets/3.0sweater+darkteal+iconsetting.png";
+import ArisaMakesLogo from '../../assets/icon_234.png';
+import WatchCakeDarkTeal from '../../assets/3.0cake+darkteal.png';
+import WatchRowCounterList from '../../assets/3.0rowcounterlist.png';
+import WatchCrochetHankPinkSetting from '../../assets/3.0crochethank+pinksettings.png';
+import WatchCrochetHankPinkDetail from '../../assets/3.0crochethank+pinkdetail.png';
+import WatchSweaterDarktealIconSetting from '../../assets/3.0sweater+darkteal+iconsetting.png';
 ---
 
 <Layout title="Apple Watch Row Counter">
   <div class="bg-gray-50">
-<div class="text-center text-2xl m-auto px-5 md:max-w-2xl py-5 ">
-<h1 class="text-4xl font-extrabold my-8">ArisaMakes Row Counter App</h1>
-		<img
-          alt="ArisaMakes Row Counter App Icon of Skeins and a Cake of Yarn"
-          title="ArisaMakes Row Counter App Icon of Skeins and a Cake of Yarn"
-          class="relative mx-auto h-40 rounded-full object-cover"
-          decoding="auto"
-          src={ArisaMakesLogo.src}
-          loading="lazy"
-        />
-		<p class="pb-4 pt-4">Use this simple row counter right on your Apple Watch while you're crocheting or knitting!</p>
-        
-        <a
-      href="https://apps.apple.com/us/app/arisamakes-row-counter/id1598992914?itsct=apps_box_badge&amp;itscg=30200"
-      class="my-6 hover:shadow-xl"
-      style="
+    <div class="text-center text-2xl m-auto px-5 md:max-w-2xl py-5">
+      <h1 class="text-4xl font-extrabold my-8">ArisaMakes Row Counter App</h1>
+      <img
+        alt="ArisaMakes Row Counter App Icon of Skeins and a Cake of Yarn"
+        title="ArisaMakes Row Counter App Icon of Skeins and a Cake of Yarn"
+        class="relative mx-auto h-40 rounded-full object-cover"
+        decoding="auto"
+        src={ArisaMakesLogo.src}
+        loading="lazy"
+      />
+      <p class="pb-4 pt-4">
+        Use this simple row counter right on your Apple Watch while you're
+        crocheting or knitting!
+      </p>
+
+      <a
+        href="https://apps.apple.com/us/app/arisamakes-row-counter/id1598992914?itsct=apps_box_badge&itscg=30200"
+        class="my-6 hover:shadow-xl"
+        style="
         display: inline-block;
         overflow: hidden;
         border-radius: 13px;
         width: 250px;
         height: 83px;
       "
-    >
-      <img
-        src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1643760000"
-        alt="Download on the App Store"
-        style="border-radius: 13px; width: 250px; height: 83px"
-    /></a>
+      >
+        <img
+          src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&releaseDate=1643760000"
+          alt="Download on the App Store"
+          style="border-radius: 13px; width: 250px; height: 83px"
+        /></a
+      >
 
-    <div class="bg-(--color-blush)/50 text-xl rounded-lg mx-25 px-4 py-3 text-center">
-			
-			<p class="pl-10 font-bold">Update 3.0 is now available!</p>
+      <div
+        class="bg-(--color-blush)/50 text-xl rounded-lg mx-25 px-4 py-3 text-center"
+      >
+        <p class="pl-10 font-bold">Update 3.0 is now available!</p>
+      </div>
 
-</div>
+      <h3
+        class="my-8 flex justify-center text-3xl font-extrabold leading-8 tracking-tight text-gray-900 sm:text-3xl sm:leading-9"
+      >
+        Screenshots
+      </h3>
 
-
-  <h3
-      class="my-8 flex justify-center text-3xl font-extrabold leading-8 tracking-tight text-gray-900 sm:text-3xl sm:leading-9"
-    >
-      Screenshots
-    </h3>
-
-    <div class="flex flex-wrap">
-
-    		<img
+      <div class="flex flex-wrap">
+        <img
           alt="ArisaMakes Apple Watch Row Counter Screenshot"
           title="ArisaMakes Apple Watch Row Counter Screenshot"
           class="mt-5 mx-auto max-h-70 rounded-[8vw] lg:rounded-[2vw] object-cover shadow-lg"
@@ -63,61 +65,72 @@ import WatchSweaterDarktealIconSetting from "../../assets/3.0sweater+darkteal+ic
           loading="lazy"
         />
 
-
-		<img
+        <img
           alt="ArisaMakes Apple Watch Row Counter Screenshot of Counter List"
           title="ArisaMakes Apple Watch Row Counter Screenshot of Counter List"
-          class="mt-5 mx-auto max-h-70 rounded-[8vw] lg:rounded-[2vw]  object-cover shadow-lg"
+          class="mt-5 mx-auto max-h-70 rounded-[8vw] lg:rounded-[2vw] object-cover shadow-lg"
           decoding="auto"
           src={WatchRowCounterList.src}
           loading="lazy"
         />
 
-        		<img
+        <img
           alt="ArisaMakes Apple Watch Row Counter Screenshot of Settings"
           title="ArisaMakes Apple Watch Row Counter Screenshot of Settings"
-          class="mt-5 mx-auto max-h-70 rounded-[8vw] lg:rounded-[2vw]  object-cover shadow-lg"
+          class="mt-5 mx-auto max-h-70 rounded-[8vw] lg:rounded-[2vw] object-cover shadow-lg"
           decoding="auto"
           src={WatchCrochetHankPinkSetting.src}
           loading="lazy"
         />
 
-                		<img
+        <img
           alt="ArisaMakes Apple Watch Row Counter Screenshot of Details"
           title="ArisaMakes Apple Watch Row Counter Screenshot of Details"
-          class="mt-5 mx-auto max-h-70 rounded-[8vw] lg:rounded-[2vw]  object-cover shadow-lg"
+          class="mt-5 mx-auto max-h-70 rounded-[8vw] lg:rounded-[2vw] object-cover shadow-lg"
           decoding="auto"
           src={WatchCrochetHankPinkDetail.src}
           loading="lazy"
         />
 
-                		<img
+        <img
           alt="ArisaMakes Apple Watch Row Counter Screenshot of Icon Setting"
           title="ArisaMakes Apple Watch Row Counter Screenshot of Icon Setting"
-          class="mt-5 mx-auto max-h-70 rounded-[8vw] lg:rounded-[2vw]  object-cover shadow-lg"
+          class="mt-5 mx-auto max-h-70 rounded-[8vw] lg:rounded-[2vw] object-cover shadow-lg"
           decoding="auto"
           src={WatchSweaterDarktealIconSetting.src}
           loading="lazy"
         />
-</div>
+      </div>
 
-<div class="mx-10 mt-10 text-xl">
-<p class="py-4">
-A simple row counter right on your Apple Watch for your crochet and knit projects! 
-</p>
-<p>
-<strong>Features include:</strong>
-</p>
-<ul class="mt-4 ml-15 text-xl list-disc list-inside">
-<li><strong>Multiple Row Counters</strong>: Create up to 10 row counters to track multiple projects!</li>
-<li><strong>Track Row Repeats</strong>: Automatically reset the counter on a specific row to track repeats. Helpful for when following a repeating pattern!</li>
-<li><strong>Customizable Counter</strong>: Customize your row counter with 6 hand-drawn icons and 5 background colors.</li>
-<li><strong>Save History</strong>: Tracks every increase or decrease on the counter with the date and time. You can tap the entry to rollback to a previous save!</li>
-</ul>
-
-</div>
-
+      <div class="mx-10 mt-10 text-xl">
+        <p class="py-4">
+          A simple row counter right on your Apple Watch for your crochet and
+          knit projects!
+        </p>
+        <p>
+          <strong>Features include:</strong>
+        </p>
+        <ul class="mt-4 ml-15 text-xl list-disc list-inside">
+          <li>
+            <strong>Multiple Row Counters</strong>: Create up to 10 row counters
+            to track multiple projects!
+          </li>
+          <li>
+            <strong>Track Row Repeats</strong>: Automatically reset the counter
+            on a specific row to track repeats. Helpful for when following a
+            repeating pattern!
+          </li>
+          <li>
+            <strong>Customizable Counter</strong>: Customize your row counter
+            with 6 hand-drawn icons and 5 background colors.
+          </li>
+          <li>
+            <strong>Save History</strong>: Tracks every increase or decrease on
+            the counter with the date and time. You can tap the entry to
+            rollback to a previous save!
+          </li>
+        </ul>
+      </div>
     </div>
-</div>
-
+  </div>
 </Layout>

--- a/arisamakes-website/src/pages/rowcounter/watchos.astro
+++ b/arisamakes-website/src/pages/rowcounter/watchos.astro
@@ -107,29 +107,29 @@ import WatchSweaterDarktealIconSetting from '../../assets/3.0sweater+darkteal+ic
           A simple row counter right on your Apple Watch for your crochet and
           knit projects!
         </p>
-        <p>
-          <strong>Features include:</strong>
-        </p>
-        <ul class="mt-4 ml-15 text-xl list-disc list-inside">
-          <li>
-            <strong>Multiple Row Counters</strong>: Create up to 10 row counters
-            to track multiple projects!
-          </li>
-          <li>
-            <strong>Track Row Repeats</strong>: Automatically reset the counter
-            on a specific row to track repeats. Helpful for when following a
-            repeating pattern!
-          </li>
-          <li>
-            <strong>Customizable Counter</strong>: Customize your row counter
-            with 6 hand-drawn icons and 5 background colors.
-          </li>
-          <li>
-            <strong>Save History</strong>: Tracks every increase or decrease on
-            the counter with the date and time. You can tap the entry to
-            rollback to a previous save!
-          </li>
-        </ul>
+        <section class="font-sans">
+          <p>Features include:</p>
+          <ul class="mt-4 ml-15 text-xl list-disc list-inside">
+            <li>
+              <strong>Multiple Row Counters</strong>: Create up to 10 row
+              counters to track multiple projects!
+            </li>
+            <li>
+              <strong>Track Row Repeats</strong>: Automatically reset the
+              counter on a specific row to track repeats. Helpful for when
+              following a repeating pattern!
+            </li>
+            <li>
+              <strong>Customizable Counter</strong>: Customize your row counter
+              with 6 hand-drawn icons and 5 background colors.
+            </li>
+            <li>
+              <strong>Save History</strong>: Tracks every increase or decrease
+              on the counter with the date and time. You can tap the entry to
+              rollback to a previous save!
+            </li>
+          </ul>
+        </section>
       </div>
     </div>
   </div>

--- a/arisamakes-website/src/pages/rowcounter/watchos.astro
+++ b/arisamakes-website/src/pages/rowcounter/watchos.astro
@@ -53,7 +53,7 @@ import WatchSweaterDarktealIconSetting from '../../assets/3.0sweater+darkteal+ic
         id="screenshots"
         class="my-8 flex justify-center text-3xl font-extrabold leading-8 tracking-tight text-gray-900 sm:text-3xl sm:leading-9"
       >
-        Screenshots
+        <a href="#screenshots">Screenshots</a>
       </h2>
 
       <div class="flex flex-wrap">
@@ -113,7 +113,7 @@ import WatchSweaterDarktealIconSetting from '../../assets/3.0sweater+darkteal+ic
             id="featured"
             class="mt-8 flex justify-center text-2xl leading-8 tracking-tight text-gray-900 sm:text-3xl sm:leading-9"
           >
-            Features include:
+            <a href="#featured">Features include:</a>
           </h2>
           <ul class="mt-2 ml-15 text-xl list-disc text-left list-outside">
             <li class="py-2">


### PR DESCRIPTION
### Overview

- improve readability of features list
- fix headings to match correct depth
- make headings navigable
- configure default formatter

### Details

When I deployed arisamakes.com with latest changes for watchOS 3.0 update, one thing I noticed is that there isn't a difference between the look of the `<strong>` text and the regular text. I double checked the `font-weights` and they correctly had different values so the text should look different.

Upon further inspection, the font that we are using -- [LXGWMarkerGothic-Regular](https://fonts.google.com/specimen/LXGW+Marker+Gothic) -- only supports `font-weight: 400`.

<img width="1778" height="1228" alt="screenshot of google fonts showing font-weight choices" src="https://github.com/user-attachments/assets/761e1ec1-2a47-4c3e-aeea-1f079c3d4dc2" />

### Screenshots

**Before**
<img width="889" height="614" alt="featured list before" src="https://github.com/user-attachments/assets/8dd1d141-1f14-422c-8fc7-a959e190b142" />

**After**
<img width="889" height="614" alt="featured list after" src="https://github.com/user-attachments/assets/a5529668-250c-4d44-aad6-89424c8b9e76" />
